### PR TITLE
Set MSRV and set full versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,18 @@ edition = "2024"
 keywords = ["fix", "fast", "protocol", "parser"]
 license = "MIT"
 repository = "https://github.com/mcsakoff/rs-fastlib"
+rust-version = "1.88.0"
 
 [dependencies]
-bytes = "1"
-hashbrown = "0.16"
-roxmltree = "0.21"
-serde = { version = "1.0", optional = true }
-thiserror = "2"
+bytes = "1.11.1"
+hashbrown = "0.16.1"
+roxmltree = "0.21.1"
+serde = { version = "1.0.228", optional = true }
+thiserror = "2.0.18"
 
 [dev-dependencies]
-serde_derive = "1.0"
-serde_bytes = "0.11"
+serde_derive = "1.0.228"
+serde_bytes = "0.11.19"
 
 [features]
 default = ["serde"]


### PR DESCRIPTION
1. Set MSRV in Cargo.toml
2. Set full dependency version. Otherwise Cargo may bump version (especially for 0.x) and break builds.