### PR TITLE
Clippy pedantic fix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Format
       run: cargo fmt --check
+    - name: Clippy
+      run: cargo clippy --all -- -W clippy::pedantic  -D warnings 
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/base/message.rs
+++ b/src/base/message.rs
@@ -56,6 +56,7 @@ pub trait MessageFactory {
 ///
 /// The callback functions are called when the specific information required during message processing.
 ///
+#[allow(clippy::missing_errors_doc)]
 pub trait MessageVisitor {
     fn get_template_name(&mut self) -> Result<String>;
 

--- a/src/base/types.rs
+++ b/src/base/types.rs
@@ -35,12 +35,10 @@ impl Template {
             .to_string();
         let type_ref = node
             .attribute("typeRef")
-            .map(TypeRef::from_str)
-            .unwrap_or(TypeRef::Any);
+            .map_or(TypeRef::Any, TypeRef::from_str);
         let dictionary = node
             .attribute("dictionary")
-            .map(Dictionary::from_str)
-            .unwrap_or(Dictionary::Global);
+            .map_or(Dictionary::Global, Dictionary::from_str);
         let mut instructions = Vec::new();
         for child in node.children() {
             if child.is_element() {
@@ -79,7 +77,7 @@ impl Operator {
             "increment" => Ok(Self::Increment),
             "delta" => Ok(Self::Delta),
             "tail" => Ok(Self::Tail),
-            _ => Err(Error::Static(format!("Unknown operator: {}", t))),
+            _ => Err(Error::Static(format!("Unknown operator: {t}"))),
         }
     }
 }

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -46,30 +46,30 @@ impl Context {
                 self.global.insert(key, val);
             }
             DictionaryType::Template(id) => {
-                if !self.template.contains_key(&id) {
+                if self.template.contains_key(&id) {
+                    self.template.get_mut(&id).unwrap().insert(key, val);
+                } else {
                     let mut hm = HashMap::new();
                     hm.insert(key, val);
                     self.template.insert(id, hm);
-                } else {
-                    self.template.get_mut(&id).unwrap().insert(key, val);
                 }
             }
             DictionaryType::Type(name) => {
-                if !self.type_.contains_key(&name) {
+                if self.type_.contains_key(&name) {
+                    self.type_.get_mut(&name).unwrap().insert(key, val);
+                } else {
                     let mut hm = HashMap::new();
                     hm.insert(key, val);
                     self.type_.insert(name, hm);
-                } else {
-                    self.type_.get_mut(&name).unwrap().insert(key, val);
                 }
             }
             DictionaryType::UserDefined(name) => {
-                if !self.user.contains_key(&name) {
+                if self.user.contains_key(&name) {
+                    self.user.get_mut(&name).unwrap().insert(key, val);
+                } else {
                     let mut hm = HashMap::new();
                     hm.insert(key, val);
                     self.user.insert(name, hm);
-                } else {
-                    self.user.get_mut(&name).unwrap().insert(key, val);
                 }
             }
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -6,6 +6,8 @@ use crate::model::ModelFactory;
 use crate::{Decoder, Error, Reader, Result};
 
 /// Decode single message from `Vec<u8>`.
+/// # Errors
+/// Returns error if message decode failed or if T deserialize failed.
 pub fn from_vec<'de, T>(decoder: &mut Decoder, bytes: Vec<u8>) -> Result<T>
 where
     T: Deserialize<'de>,
@@ -15,12 +17,13 @@ where
     decoder.decode_vec(bytes, &mut msg)?;
 
     // Deserialize from internal data model into user data type
-    let data = msg.data.unwrap();
-    T::deserialize(data)
+    deserialize(msg)
 }
 
 /// Decode single message from buffer.
 /// Returns the decoded message and number of bytes consumed.
+/// # Errors
+/// Returns error if message decode failed or if T deserialize failed.
 pub fn from_buffer<'de, T>(decoder: &mut Decoder, buffer: &[u8]) -> Result<(T, u64)>
 where
     T: Deserialize<'de>,
@@ -30,13 +33,13 @@ where
     let n = decoder.decode_buffer(buffer, &mut msg)?;
 
     // Deserialize from internal data model into user data type
-    let data = msg.data.unwrap();
-    let result = T::deserialize(data)?;
-    Ok((result, n))
+    deserialize(msg).map(|r| (r, n))
 }
 
 /// Decode single message from buffer.
 /// The `bytes` slice must be consumed completely. It is an error if any bytes left after the message is decoded.
+/// # Errors
+/// Returns error if message decode failed or if T deserialize failed.
 pub fn from_slice<'de, T>(decoder: &mut Decoder, bytes: &[u8]) -> Result<T>
 where
     T: Deserialize<'de>,
@@ -46,11 +49,12 @@ where
     decoder.decode_slice(bytes, &mut msg)?;
 
     // Deserialize from internal data model into user data type
-    let data = msg.data.unwrap();
-    T::deserialize(data)
+    deserialize(msg)
 }
 
 /// Decode single message from `bytes::Bytes`.
+/// # Errors
+/// Returns error if message decode failed or if T deserialize failed.
 #[allow(unused)]
 pub fn from_bytes<'de, T>(decoder: &mut Decoder, bytes: &mut bytes::Bytes) -> Result<T>
 where
@@ -61,11 +65,12 @@ where
     decoder.decode_bytes(bytes, &mut msg)?;
 
     // Deserialize from internal data model into user data type
-    let data = msg.data.unwrap();
-    T::deserialize(data)
+    deserialize(msg)
 }
 
 /// Decode single message from object that implements `fastlib::Reader` trait.
+/// # Errors
+/// Returns error if message decode failed or if T deserialize failed.
 #[allow(unused)]
 pub fn from_reader<'de, T>(decoder: &mut Decoder, rdr: &mut impl Reader) -> Result<T>
 where
@@ -76,11 +81,12 @@ where
     decoder.decode_reader(rdr, &mut msg)?;
 
     // Deserialize from internal data model into user data type
-    let data = msg.data.unwrap();
-    T::deserialize(data)
+    deserialize(msg)
 }
 
 /// Decode single message from object that implements `std::io::Read` trait.
+/// # Errors
+/// Returns error if message decode failed or if T deserialize failed.
 #[allow(unused)]
 pub fn from_stream<'de, T>(decoder: &mut Decoder, rdr: &mut dyn Read) -> Result<T>
 where
@@ -91,7 +97,19 @@ where
     decoder.decode_stream(rdr, &mut msg)?;
 
     // Deserialize from internal data model into user data type
-    let data = msg.data.unwrap();
+    deserialize(msg)
+}
+
+// Deserializes message to the given type.
+// # Errors
+// Returns error if deserialization failed.
+fn deserialize<'de, T>(msg: ModelFactory) -> Result<T>
+where
+    T: Deserialize<'de>,
+{
+    let data = msg
+        .data
+        .ok_or_else(|| Error::Runtime("No data in message".to_string()))?;
     T::deserialize(data)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,10 @@
 //! Provides `From<Decimal>` implementation for [`rust_decimal::Decimal`] and `TryFrom<rust_decimal::Decimal>` for [`Decimal`].
 //!
 //! [`rust_decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/
-
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::option_option)]
 pub use base::message::{MessageFactory, MessageVisitor};
 pub use base::{decimal::Decimal, value::Value, value::ValueType};
 pub use decoder::{decoder::Decoder, reader::Reader};

--- a/src/model/decimal.rs
+++ b/src/model/decimal.rs
@@ -24,34 +24,26 @@ impl<'de> Deserialize<'de> for Decimal {
             where
                 E: de::Error,
             {
-                match Decimal::from_string(v) {
-                    Ok(d) => Ok(d),
-                    Err(e) => Err(E::custom(e)),
-                }
+                Decimal::from_string(v).map_err(|e| E::custom(e))
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
-                match Decimal::from_string(&v) {
-                    Ok(d) => Ok(d),
-                    Err(e) => Err(E::custom(e)),
-                }
+                Decimal::from_string(&v).map_err(|e| E::custom(e))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
             where
                 A: de::SeqAccess<'de>,
             {
-                let e = match seq.next_element()? {
-                    Some(e) => e,
-                    None => return Err(de::Error::invalid_length(0, &self)),
-                };
-                let m = match seq.next_element()? {
-                    Some(m) => m,
-                    None => return Err(de::Error::invalid_length(1, &self)),
-                };
+                let e = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let m = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 Ok(Decimal::new(e, m))
             }
         }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -45,7 +45,7 @@ impl MessageFactory for ModelFactory {
 
     fn stop_template(&mut self) {
         let (name, value) = self.context.pop().unwrap();
-        self.data = Some(TemplateData { name, value })
+        self.data = Some(TemplateData { name, value });
     }
 
     fn set_value(&mut self, _id: u32, name: &str, value: Option<Value>) {
@@ -119,12 +119,12 @@ impl MessageFactory for ModelFactory {
                 value: ValueData::None,
             }));
             let rc = self.ref_num.must_peek_mut();
-            self.context.push((format!("templateRef:{}", rc), tpl_ref));
+            self.context.push((format!("templateRef:{rc}"), tpl_ref));
             *rc += 1;
         } else {
             let tpl_ref = ValueData::StaticTemplateRef(name.to_string(), Box::new(ValueData::None));
             self.context.push((name.to_string(), tpl_ref));
-        };
+        }
         self.context
             .push((String::new(), ValueData::Group(HashMap::new())));
         self.ref_num.push(0);
@@ -141,7 +141,7 @@ impl MessageFactory for ModelFactory {
                     ValueData::StaticTemplateRef(_m, _) => {
                         // Instead of inserting the group as standalone object, we inline the group into parent's context:
                         if let ValueData::Group(g) = vg {
-                            group.extend(g)
+                            group.extend(g);
                         } else {
                             unreachable!()
                         }
@@ -191,7 +191,7 @@ impl MessageVisitor for ModelVisitor {
     fn get_template_name(&mut self) -> Result<String> {
         match self.data.value {
             ValueData::Group(_) => {
-                self.context.push(&self.data.value);
+                self.context.push(&raw const self.data.value);
                 Ok(self.data.name.clone())
             }
             _ => Err(Error::Runtime(format!(
@@ -210,8 +210,7 @@ impl MessageVisitor for ModelVisitor {
                     match v {
                         ValueData::Value(v) => Ok(v.clone()),
                         _ => Err(Error::Runtime(format!(
-                            "Field {name} expected to be ValueData::Value, got {:?}",
-                            v
+                            "Field {name} expected to be ValueData::Value, got {v:?}"
                         ))),
                     }
                 } else {
@@ -236,8 +235,7 @@ impl MessageVisitor for ModelVisitor {
                             Ok(true)
                         }
                         _ => Err(Error::Runtime(format!(
-                            "Field {name} expected to be ValueData::Group, got {:?}",
-                            v
+                            "Field {name} expected to be ValueData::Group, got {v:?}"
                         ))),
                     }
                 } else {
@@ -268,8 +266,7 @@ impl MessageVisitor for ModelVisitor {
                             Ok(Some(len))
                         }
                         _ => Err(Error::Runtime(format!(
-                            "Field {name} expected to be ValueData::Sequence, got: {:?}",
-                            v
+                            "Field {name} expected to be ValueData::Sequence, got: {v:?}"
                         ))),
                     }
                 } else {
@@ -293,8 +290,7 @@ impl MessageVisitor for ModelVisitor {
                             Ok(())
                         }
                         _ => Err(Error::Runtime(format!(
-                            "Sequence item #{index} expected to be ValueData::Group, got {:?}",
-                            v
+                            "Sequence item #{index} expected to be ValueData::Group, got {v:?}"
                         ))),
                     }
                 } else {
@@ -320,7 +316,7 @@ impl MessageVisitor for ModelVisitor {
         self.ref_dynamic.push(dynamic);
         if dynamic {
             let rc = self.ref_num.must_peek_mut();
-            let name = format!("templateRef:{}", rc);
+            let name = format!("templateRef:{rc}");
             *rc += 1;
             self.ref_num.push(0);
 
@@ -334,7 +330,7 @@ impl MessageVisitor for ModelVisitor {
                             ValueData::DynamicTemplateRef(t) => match t.value {
                                 ValueData::Group(_) => {
                                     let template_name = t.name.clone();
-                                    self.context.push(&t.value);
+                                    self.context.push(&raw const t.value);
                                     Ok(Some(template_name))
                                 }
                                 _ => Err(Error::Runtime(format!(
@@ -343,8 +339,7 @@ impl MessageVisitor for ModelVisitor {
                                 ))),
                             },
                             _ => Err(Error::Runtime(format!(
-                                "Field {name} expected to be ValueData::DynamicTemplateRef, got {:?}",
-                                v
+                                "Field {name} expected to be ValueData::DynamicTemplateRef, got {v:?}"
                             ))),
                         }
                     } else {

--- a/src/model/value.rs
+++ b/src/model/value.rs
@@ -36,16 +36,14 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                     Value::UInt64(n) => visitor.visit_u64(n),
                     Value::Int64(n) => visitor.visit_i64(n),
                     Value::Decimal(f) => visitor.visit_f64(f.to_float()),
-                    Value::ASCIIString(s) => visitor.visit_string(s),
-                    Value::UnicodeString(s) => visitor.visit_string(s),
+                    Value::ASCIIString(s) | Value::UnicodeString(s) => visitor.visit_string(s),
                     Value::Bytes(b) => visitor.visit_byte_buf(b),
                 },
             },
             ValueData::Group(_) => self.deserialize_map(visitor),
             ValueData::Sequence(_) => self.deserialize_seq(visitor),
             _ => Err(Error::Runtime(format!(
-                "deserialize_any: data model unsupported type: {:?}",
-                self
+                "deserialize_any: data model unsupported type: {self:?}"
             ))),
         }
     }
@@ -81,14 +79,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 Some(v) => match v {
                     Value::Int32(n) => visitor.visit_i32(n),
                     _ => Err(Error::Runtime(format!(
-                        "deserialize_i32: data model must be Value::Int32, got: {:?}",
-                        v
+                        "deserialize_i32: data model must be Value::Int32, got: {v:?}"
                     ))),
                 },
             },
             _ => Err(Error::Runtime(format!(
-                "deserialize_i32: data model must be ValueData::Value, got: {:?}",
-                self
+                "deserialize_i32: data model must be ValueData::Value, got: {self:?}"
             ))),
         }
     }
@@ -103,14 +99,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 Some(v) => match v {
                     Value::Int64(n) => visitor.visit_i64(n),
                     _ => Err(Error::Runtime(format!(
-                        "deserialize_i64: data model must be Value::Int64, got: {:?}",
-                        v
+                        "deserialize_i64: data model must be Value::Int64, got: {v:?}"
                     ))),
                 },
             },
             _ => Err(Error::Runtime(format!(
-                "deserialize_i64: data model must be ValueData::Value, got: {:?}",
-                self
+                "deserialize_i64: data model must be ValueData::Value, got: {self:?}"
             ))),
         }
     }
@@ -139,14 +133,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 Some(v) => match v {
                     Value::UInt32(n) => visitor.visit_u32(n),
                     _ => Err(Error::Runtime(format!(
-                        "deserialize_u64: data model must be Value::UInt32, got: {:?}",
-                        v
+                        "deserialize_u64: data model must be Value::UInt32, got: {v:?}"
                     ))),
                 },
             },
             _ => Err(Error::Runtime(format!(
-                "deserialize_u64: data model must be ValueData::Value, got: {:?}",
-                self
+                "deserialize_u64: data model must be ValueData::Value, got: {self:?}"
             ))),
         }
     }
@@ -161,14 +153,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 Some(v) => match v {
                     Value::UInt64(n) => visitor.visit_u64(n),
                     _ => Err(Error::Runtime(format!(
-                        "deserialize_u64: data model must be Value::UInt64, got: {:?}",
-                        v
+                        "deserialize_u64: data model must be Value::UInt64, got: {v:?}"
                     ))),
                 },
             },
             _ => Err(Error::Runtime(format!(
-                "deserialize_u64: data model must be ValueData::Value, got: {:?}",
-                self
+                "deserialize_u64: data model must be ValueData::Value, got: {self:?}"
             ))),
         }
     }
@@ -190,14 +180,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 Some(v) => match v {
                     Value::Decimal(n) => visitor.visit_f64(n.to_float()),
                     _ => Err(Error::Runtime(format!(
-                        "deserialize_f64: data model must be Value::Decimal, got: {:?}",
-                        v
+                        "deserialize_f64: data model must be Value::Decimal, got: {v:?}"
                     ))),
                 },
             },
             _ => Err(Error::Runtime(format!(
-                "deserialize_f64: data model must be ValueData::Value, got: {:?}",
-                self
+                "deserialize_f64: data model must be ValueData::Value, got: {self:?}"
             ))),
         }
     }
@@ -219,14 +207,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                         }
                     }
                     _ => Err(Error::Runtime(format!(
-                        "deserialize_char: data model must be Value::ASCIIString or Value::UnicodeString, got: {:?}",
-                        v
+                        "deserialize_char: data model must be Value::ASCIIString or Value::UnicodeString, got: {v:?}"
                     ))),
                 },
             },
             _ => Err(Error::Runtime(format!(
-                "deserialize_char: data model must be ValueData::Value, got: {:?}",
-                self
+                "deserialize_char: data model must be ValueData::Value, got: {self:?}"
             ))),
         }
     }
@@ -248,14 +234,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 Some(v) => match v {
                     Value::ASCIIString(s) | Value::UnicodeString(s) => visitor.visit_string(s),
                     _ => Err(Error::Runtime(format!(
-                        "deserialize_string: data model must be Value::ASCIIString or Value::UnicodeString, got: {:?}",
-                        v
+                        "deserialize_string: data model must be Value::ASCIIString or Value::UnicodeString, got: {v:?}"
                     ))),
                 },
             },
             _ => Err(Error::Runtime(format!(
-                "deserialize_string: data model must be ValueData::Value, got: {:?}",
-                self
+                "deserialize_string: data model must be ValueData::Value, got: {self:?}"
             ))),
         }
     }
@@ -277,14 +261,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 Some(v) => match v {
                     Value::Bytes(b) => visitor.visit_byte_buf(b),
                     _ => Err(Error::Runtime(format!(
-                        "deserialize_byte_buf: data model must be Value::Bytes, got: {:?}",
-                        v
+                        "deserialize_byte_buf: data model must be Value::Bytes, got: {v:?}"
                     ))),
                 },
             },
             _ => Err(Error::Runtime(format!(
-                "deserialize_string: data model must be ValueData::Value, got: {:?}",
-                self
+                "deserialize_string: data model must be ValueData::Value, got: {self:?}"
             ))),
         }
     }
@@ -299,11 +281,9 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 None => visitor.visit_none(),
                 Some(_) => visitor.visit_some(self),
             },
-            ValueData::Group(_) => visitor.visit_some(self),
-            ValueData::Sequence(_) => visitor.visit_some(self),
+            ValueData::Group(_) | ValueData::Sequence(_) => visitor.visit_some(self),
             _ => Err(Error::Runtime(format!(
-                "deserialize_option: cannot be optional, got: {:?}",
-                self
+                "deserialize_option: cannot be optional, got: {self:?}"
             ))),
         }
     }
@@ -344,8 +324,7 @@ impl<'de> serde::Deserializer<'de> for ValueData {
         match self {
             ValueData::Sequence(q) => visitor.visit_seq(SequenceDeserializer::new(q)),
             _ => Err(Error::Runtime(format!(
-                "deserialize_seq: data model must be ValueData::Sequence, got {:?}",
-                self
+                "deserialize_seq: data model must be ValueData::Sequence, got {self:?}"
             ))),
         }
     }
@@ -371,14 +350,12 @@ impl<'de> serde::Deserializer<'de> for ValueData {
                 visitor.visit_seq(d)
             } else {
                 Err(Error::Runtime(format!(
-                    "deserialize_tuple_struct: expected Value::Decimal, got {:?}",
-                    self
+                    "deserialize_tuple_struct: expected Value::Decimal, got {self:?}"
                 )))
             };
         }
         Err(Error::Runtime(format!(
-            "deserialize_seq: unsupported data model {:?}",
-            self
+            "deserialize_seq: unsupported data model {self:?}"
         )))
     }
 
@@ -389,8 +366,7 @@ impl<'de> serde::Deserializer<'de> for ValueData {
         match self {
             ValueData::Group(group) => visitor.visit_map(GroupDeserializer::new(group)),
             _ => Err(Error::Runtime(format!(
-                "deserialize_map: data model must be ValueData::Group, got: {:?}",
-                self
+                "deserialize_map: data model must be ValueData::Group, got: {self:?}"
             ))),
         }
     }
@@ -419,8 +395,7 @@ impl<'de> serde::Deserializer<'de> for ValueData {
         match self {
             ValueData::DynamicTemplateRef(t) => t.deserialize_enum(name, variants, visitor),
             _ => Err(Error::Runtime(format!(
-                "deserialize_enum: data model must be ValueData::DynamicTemplateRef, got: {:?}",
-                self
+                "deserialize_enum: data model must be ValueData::DynamicTemplateRef, got: {self:?}"
             ))),
         }
     }
@@ -538,11 +513,11 @@ impl serde::Serializer for ValueDataSerializer {
     }
 
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        Ok(ValueData::Value(Some(Value::Int32(v as i32))))
+        Ok(ValueData::Value(Some(Value::Int32(i32::from(v)))))
     }
 
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        Ok(ValueData::Value(Some(Value::Int32(v as i32))))
+        Ok(ValueData::Value(Some(Value::Int32(i32::from(v)))))
     }
 
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
@@ -554,11 +529,11 @@ impl serde::Serializer for ValueDataSerializer {
     }
 
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        Ok(ValueData::Value(Some(Value::UInt32(v as u32))))
+        Ok(ValueData::Value(Some(Value::UInt32(u32::from(v)))))
     }
 
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        Ok(ValueData::Value(Some(Value::UInt32(v as u32))))
+        Ok(ValueData::Value(Some(Value::UInt32(u32::from(v)))))
     }
 
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
@@ -571,7 +546,7 @@ impl serde::Serializer for ValueDataSerializer {
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
         Ok(ValueData::Value(Some(Value::Decimal(Decimal::from_float(
-            v as f64,
+            f64::from(v),
         )?))))
     }
 
@@ -816,17 +791,15 @@ impl SerializeMap for ValueDataMapSerializer {
         K: ?Sized + Serialize,
         V: ?Sized + Serialize,
     {
-        let key = match key.serialize(ValueDataSerializer)? {
-            ValueData::Value(Some(Value::ASCIIString(s))) => s,
-            ValueData::Value(Some(Value::UnicodeString(s))) => s,
-            _ => {
-                return Err(Error::Runtime(
-                    "serialize_entry: key must be a string".to_string(),
-                ));
-            }
+        let ValueData::Value(Some(Value::ASCIIString(s) | Value::UnicodeString(s))) =
+            key.serialize(ValueDataSerializer)?
+        else {
+            return Err(Error::Runtime(
+                "serialize_entry: key must be a string".to_string(),
+            ));
         };
         let value = value.serialize(ValueDataSerializer)?;
-        self.data.insert(key, value);
+        self.data.insert(s, value);
         Ok(())
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -7,6 +7,8 @@ use crate::model::template::TemplateData;
 use crate::{Encoder, Error, Result, Writer};
 
 /// Encode single message into `Vec<u8>`.
+/// # Errors
+/// Will return Err if serialization failed.
 #[allow(unused)]
 pub fn to_vec<T>(encoder: &mut Encoder, value: &T) -> Result<Vec<u8>>
 where
@@ -22,6 +24,8 @@ where
 }
 
 /// Encode single message into `bytes::BufMut`.
+/// # Errors
+/// Will return Err if serialization failed.
 #[allow(unused)]
 pub fn to_bytes<T>(encoder: &mut Encoder, value: &T) -> Result<bytes::BytesMut>
 where
@@ -37,6 +41,8 @@ where
 }
 
 /// Encode single message into object that implements `fastlib::Writer` trait.
+/// # Errors
+/// Will return Err if serialization failed.
 #[allow(unused)]
 pub fn to_writer<T>(encoder: &mut Encoder, wrt: &mut impl Writer, value: &T) -> Result<()>
 where
@@ -52,6 +58,8 @@ where
 }
 
 /// Encode single message into object that implements `std::io::Write` trait.
+/// # Errors
+/// Will return Err if serialization failed.
 #[allow(unused)]
 pub fn to_stream<T>(encoder: &mut Encoder, wrt: &mut dyn Write, value: &T) -> Result<()>
 where
@@ -66,8 +74,10 @@ where
     encoder.encode_stream(wrt, &mut msg)
 }
 
-/// Encode single message into pre-allocated buffer .
+/// Encode single message into pre-allocated buffer.
 /// Returns number of bytes written.
+/// # Errors
+/// Will return Err if serialization failed.
 #[allow(unused)]
 pub fn to_buffer<T>(encoder: &mut Encoder, buffer: &mut [u8], value: &T) -> Result<usize>
 where

--- a/src/utils/stacked.rs
+++ b/src/utils/stacked.rs
@@ -25,7 +25,7 @@ impl<T> Stacked<T> {
             Some(old) => {
                 self.stack.push(old);
             }
-        };
+        }
     }
 
     pub fn pop(&mut self) -> Option<T> {


### PR DESCRIPTION
1. Fixed clippy pedantic warnings.
2. Added check on CI

Most of issues (~60%) fixed automatically.
Small part required manual code refactoring (like `Instrument::extract/inject`).

Disabled next checks globally for crate:
cast_possible_truncation
cast_possible_wrap
cast_sign_loss
option_option

Fixing them may cause huge refactoring or perfomance problems so I decided to disable them at all.